### PR TITLE
JVCControl: add special handling for PMCV command

### DIFF
--- a/HTWebRemoteHost/Devices/Controllers/JVCControl.cs
+++ b/HTWebRemoteHost/Devices/Controllers/JVCControl.cs
@@ -59,6 +59,11 @@ namespace HTWebRemoteHost.Devices.Controllers
 
                             try
                             {
+                                if (cmd == "PMCV")
+                                {
+                                    param = getLaserLevel(param);
+                                }
+
                                 //+ turns into space via querystring
                                 if ((param.StartsWith("+") || param.StartsWith(" ")) && param.Length > 1)
                                 {
@@ -93,14 +98,29 @@ namespace HTWebRemoteHost.Devices.Controllers
                     }
                     else
                     {
-                        Util.ErrorHandler.SendError($"PJACK not recieved.");
+                        Util.ErrorHandler.SendError("PJACK not received.");
                     }
                 }
                 else
                 {
-                    Util.ErrorHandler.SendError($"PJ_OK not recieved.");
+                    Util.ErrorHandler.SendError("PJ_OK not received.");
                 }
             }
+        }
+
+        private static string getLaserLevel(string param)
+        {
+            byte percent;
+            if (!byte.TryParse(param, out percent))
+            {
+                return param;
+            }
+            if (percent > 100)
+            {
+                return param;
+            }
+            double scaled = 109 + Math.Floor(1.1 * percent + 0.5);
+            return "+" + scaled.ToString("F0");
         }
     }
 }


### PR DESCRIPTION
The PMCV command was added with JVC Firmware 3.0 and allows setting the laser level to an integer percentage between 0-100. However, the percentage is not sent as a straight numeric parameter. Rather, the 0-100 value first needs to be scaled by 1.1, then 109 needs to be added such that the final numeric parameter ranges from 109-219.

This commit teaches JVCControl the special handling needed for the PMCV command when the parameter is a string representing a number between 0 and 100 inclusive.

See AVSForum discussion:

- https://www.avsforum.com/threads/jvc-nz-series-fw-3-0.3287892/page-10#post-62971284
- https://www.avsforum.com/threads/htwebremote-simple-remote-control-of-your-home-theater-devices-and-htpc-from-any-web-browser.3141648/page-63#post-62975292